### PR TITLE
Fix EditableTitle input styles in Firefox

### DIFF
--- a/src/ui/components/EditableTitle/component.ts
+++ b/src/ui/components/EditableTitle/component.ts
@@ -11,11 +11,6 @@ export default class extends Component {
     return this.bounds.firstNode as HTMLElement;
   }
 
-  didInsertElement() {
-    let style = window.getComputedStyle(this.element);
-    this.inputStyle = `font: ${style.font}; color: ${style.color};`;
-  }
-
   didUpdate() {
     setTimeout(() => {
       let input: HTMLElement = this.element.querySelector('input');

--- a/src/ui/styles/components/editable-title.scss
+++ b/src/ui/styles/components/editable-title.scss
@@ -13,6 +13,9 @@ editable-title {
   > input {
     border: 0;
     background-color: $base02;
+    color: $blue;
+    font-size: 1.2rem;
+    @include monospace;
     outline: none;
   }
 }


### PR DESCRIPTION
``` javascript
this.inputStyle = `font: ${style.font}; color: ${style.color};`;
```

Looks like Firefox is not a fan of `style.font`. The key `font` is in the object but the value is always an empty string.

<img width="289" alt="screen shot 2017-10-28 at 12 57 16 pm" src="https://user-images.githubusercontent.com/3692/32138026-6237cb06-bbe0-11e7-8792-a024a2efb01a.png">

A little CSS duplication never hurt anyone, right? :-D