### PR TITLE
Remove Delete Button for Helper Implementation

### DIFF
--- a/src/ui/components/Main/component.ts
+++ b/src/ui/components/Main/component.ts
@@ -201,12 +201,6 @@ export default class extends Component {
     this.components = this.components;
   }
 
-  removeHelperImplementation(files: HelperFiles) {
-    files.helper.remove();
-    files.helper = null;
-    this.helpers = this.helpers;
-  }
-
   private nameChanged(files: ComponentFiles | HelperFiles, name) {
     files.name = name;
     this.fs.didChange();

--- a/src/ui/components/Main/template.hbs
+++ b/src/ui/components/Main/template.hbs
@@ -57,7 +57,6 @@
           <div class="file implementation">
             <h3 class="file-name">
               helper.ts
-              <RemoveButton @onClick={{action removeHelperImplementation helper}} />
             </h3>
             <CodeEditor @file={{helper.helper}} />
           </div>


### PR DESCRIPTION
I'm probably missing something but it looks like the helper implementation should not have a delete button. Once it is removed another cannot be added and attempting to remove the helper causes an error. Also, the playground will be stuck with that empty helper... _forever_.

![boom](https://user-images.githubusercontent.com/3692/32147242-586aa7f8-bca1-11e7-95ee-1e1c225444b8.gif)