### PR TITLE
Improve Visualizer view

### DIFF
--- a/src/ui/components/Visualizer/-utils/hexdump.ts
+++ b/src/ui/components/Visualizer/-utils/hexdump.ts
@@ -35,7 +35,7 @@ function _fillUp(value, count, fillWith) {
 export default function hexdump(arrayBuffer, offset = 0, length = arrayBuffer.byteLength) {
   let view = new DataView(arrayBuffer);
 
-  let out = _fillUp("Offset", 8, " ") + "  00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F\n";
+  let out = _fillUp("Offset", 8, " ") + "  00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F\n\n";
   let row = "";
   for (let i = 0; i < length; i += 16) {
     row += _fillUp(offset.toString(16).toUpperCase(), 8, "0") + "  ";

--- a/src/ui/components/Visualizer/-utils/inspect-program.ts
+++ b/src/ui/components/Visualizer/-utils/inspect-program.ts
@@ -30,6 +30,7 @@ export function inspect(map: {}) {
 
   return {
     hexdump: hexdump(heap.buffer),
+    byteLength: heap.buffer.byteLength,
     buffer,
     opcodes,
     pool

--- a/src/ui/components/Visualizer/template.hbs
+++ b/src/ui/components/Visualizer/template.hbs
@@ -26,6 +26,9 @@
       </div>
     {{/each}}
   </div>
+  <div class="byte-length">
+    <pre>    Size  {{compilation.byteLength}} Bytes</pre>
+  </div>
   <div class="hexdump">
     <pre>{{compilation.hexdump}}</pre>
   </div>

--- a/src/ui/styles/components/glimmer-visualizer.scss
+++ b/src/ui/styles/components/glimmer-visualizer.scss
@@ -48,7 +48,11 @@ glimmer-visualizer {
       font-family: Menlo, Courier, monospace;
     }
   }
-  
+
+  .byte-length {
+    margin: 1em 0;
+  }
+
   .bytecode {
     margin-top: 17px;
 


### PR DESCRIPTION
![bildschirmfoto 2018-02-15 um 20 32 41](https://user-images.githubusercontent.com/141300/36276844-65458b02-128f-11e8-8ba3-7dbd7d67fd89.png)

This PR adds an extra blank line below the "Offset" line to separate it from the actual template bytes. Without this it looked like the offset bytes were already part of the template on first glance.

The PR also adds a "Size" indicator to highlight just how small binary Glimmer templates are.